### PR TITLE
Add support for extra program options providers

### DIFF
--- a/application_base.cpp
+++ b/application_base.cpp
@@ -198,7 +198,7 @@ void application_base::register_config_type_comparison(std::type_index i, config
    my->_any_compare_map.emplace(i, comp);
 }
 
-void application_base::set_program_options()
+void application_base::set_program_options(const std::vector<extra_program_options_provider>& option_providers)
 {
    for(auto& plug : plugins) {
       boost::program_options::options_description plugin_cli_opts("Command Line Options for " + plug.second->name());
@@ -228,13 +228,18 @@ void application_base::set_program_options()
          ("logconf,l", bpo::value<std::string>()->default_value( "logging.json" ),
             "Logging configuration file name/path for library users (absolute path or relative to application config dir)");
 
+   for (auto & op : option_providers ) {
+      op(app_cfg_opts, app_cli_opts);
+   }
+
    my->_cfg_options.add(app_cfg_opts);
    my->_app_options.add(app_cfg_opts);
    my->_app_options.add(app_cli_opts);
 }
 
-bool application_base::initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging) {
-   set_program_options();
+bool application_base::initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging,
+   std::vector<application_base::extra_program_options_provider> extra_program_options_providers) {
+   set_program_options(extra_program_options_providers);
 
    bpo::variables_map& options = my->_options;
    try {

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -106,6 +106,7 @@ public:
     * @tparam Plugin List of plugins to initalize even if not mentioned by configuration. For plugins started by
     * configuration settings or dependency resolution, this template has no effect.
     * @param initialize_logging Function pointer that will be invoked to initialize logging
+    * @param extra_program_options_providers List of extra program options providers to use during initialization
     * @return true if the application and plugins were initialized, false or exception on error
     */
    template <typename... Plugin>

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -29,9 +29,6 @@ class application_base {
 public:
    using extra_program_options_provider = std::function<void(bpo::options_description&, bpo::options_description&)>;
 
-   /**
-    * Destructor
-    */
    ~application_base();
 
    /** @brief Set version

--- a/include/appbase/application_base.hpp
+++ b/include/appbase/application_base.hpp
@@ -27,8 +27,12 @@ struct priority {
 
 class application_base {
 public:
-   ~application_base();
+   using extra_program_options_provider = std::function<void(bpo::options_description&, bpo::options_description&)>;
 
+   /**
+    * Destructor
+    */
+   ~application_base();
 
    /** @brief Set version
     *
@@ -108,13 +112,14 @@ public:
     * @return true if the application and plugins were initialized, false or exception on error
     */
    template <typename... Plugin>
-   bool initialize(int argc, char** argv, std::function<void()> initialize_logging={}) {
+   bool initialize(int argc, char** argv, std::function<void()> initialize_logging={},
+      std::vector<application_base::extra_program_options_provider> extra_program_options_providers = {}) {
       // REGISTER ALL PLUGINS (EXISTING REGISTRATIONS ARE RESPECTED)
       (_register_plugin<Plugin>(), ...);
 
       for (const auto& entry : plugin_registrations)
          entry.second(*this);
-      return initialize_impl(argc, argv, {find_plugin<Plugin>()...}, initialize_logging);
+      return initialize_impl(argc, argv, {find_plugin<Plugin>()...}, initialize_logging, extra_program_options_providers);
    }
 
    void startup(boost::asio::io_context& io_ctx);
@@ -314,7 +319,8 @@ protected:
    template <typename Impl>
    friend class plugin;
 
-   bool initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging);
+   bool initialize_impl(int argc, char** argv, vector<abstract_plugin*> autostart_plugins, std::function<void()> initialize_logging,
+      std::vector<application_base::extra_program_options_provider> extra_program_options_providers = {});
 
    /** these notifications get called from the plugin when their state changes so that
     * the application can call shutdown in the reverse order.
@@ -355,7 +361,8 @@ private:
    inline static std::vector<plugin_registration_entry> plugin_registrations;
 
    void start_sighup_handler(std::shared_ptr<boost::asio::signal_set> sighup_set);
-   void set_program_options();
+
+   void set_program_options(const std::vector<extra_program_options_provider>& option_providers = {});
    void write_default_config(const std::filesystem::path& cfg_file);
    void print_default_config(std::ostream& os);
 


### PR DESCRIPTION
### Description of Changes

This pull request adds support for providing additional program option providers in the `application_base` module. The following updates are included:

- `set_program_options` was updated to accept and apply extra option providers.
- `initialize` and `initialize_impl` were modified to pass the additional program option providers.

### Checklist

- [ ] Code compiles without errors.
- [ ] Tests have been added or updated, if applicable.
- [ ] Documentation has been updated, if applicable.
- [ ] All relevant automated checks pass.
